### PR TITLE
Benchmark hangs when no tests are selected

### DIFF
--- a/docs/support/boot.js
+++ b/docs/support/boot.js
@@ -397,6 +397,11 @@
 
       var benchmarkSuite = createBenchmarkSuite();
 
+      // No benchmarks selected
+      if (benchmarkSuite.length === 0) {
+        finishedLoading();
+      }
+
       var currentResultSet = [];
       benchmarkSuite.on("cycle", function(e) {
         var benchmarkSetId = e.target.benchmarkSetId;


### PR DESCRIPTION
triggers `finishedLoading` if no tests are selected
