### PR TITLE
Sequence handling for FlattenedSequence

### DIFF
--- a/lib/sequence.js
+++ b/lib/sequence.js
@@ -1469,17 +1469,25 @@ var FlattenedSequence = CachingSequence.inherit(function(parent) {
 });
 
 FlattenedSequence.prototype.each = function(fn) {
-  // Hack: store the index in a tiny array so we can increment it from outside
-  // this function.
-  var index = [0];
-
-  this.parent.each(function(e) {
-    if (e instanceof Array) {
-      return recursiveForEach(e, fn, index);
-    } else {
-      return fn(e, index[0]++);
+  var index      = 0,
+  recurseVisitor = function(e) {
+    if (e instanceof Sequence) {
+      return e.each(recurseVisitor);
+    } else if (e instanceof Array) {
+      var i=-1;
+      while (++i < e.length) {
+        if (recurseVisitor(e[i]) === false){
+          return false;
+        }
+      }
+      return true;
     }
-  });
+    else {
+      return fn(e,index++);
+    }
+  };
+  
+  this.parent.each(recurseVisitor);
 };
 
 var WithoutSequence = CachingSequence.inherit(function(parent, values) {


### PR DESCRIPTION
When you create sequences recursively you end up with recursive sequences. Consequently, it can be useful to flatten sub-sequences as well as arrays when calling to flatten(). This is a simple change to the FlattenedSequence implementation of each which enables this behavior.

Thanks for a neat library.  Also, you might enjoy checking out clojure or other lisp sometime if you haven't already!
- Alex
