### PR TITLE
Fix take(0)'s behavior on GeneratedSequences and test.

### DIFF
--- a/lazy.js
+++ b/lazy.js
@@ -1393,7 +1393,8 @@
     var self = this,
         i = 0;
     self.parent.each(function(e) {
-      var result = fn(e, i);
+      var result;
+      if (i < self.count) { result = fn(e, i); }
       if (++i >= self.count) { return false; }
       return result;
     });

--- a/lib/sequence.js
+++ b/lib/sequence.js
@@ -1334,7 +1334,8 @@ TakeSequence.prototype.each = function(fn) {
   var self = this,
       i = 0;
   self.parent.each(function(e) {
-    var result = fn(e, i);
+    var result;
+    if (i < self.count) { result = fn(e, i); }
     if (++i >= self.count) { return false; }
     return result;
   });

--- a/spec/lazy_spec.js
+++ b/spec/lazy_spec.js
@@ -157,6 +157,10 @@ describe("Lazy", function() {
     it("returns a sequence from start to stop, incremented by step", function() {
       expect(Lazy.range(0, 30, 5).toArray()).toEqual([0, 5, 10, 15, 20, 25]);
     });
+
+    it("returns an empty sequence when start is equal to or greater than stop", function() {
+      expect(Lazy.range(0).toArray()).toEqual([]);
+    });
   });
 
   describe("async", function() {
@@ -524,6 +528,10 @@ describe("Lazy", function() {
     it("passes an index along with each element", function() {
       expect(Lazy(people).take(2)).toPassToEach(1, [0, 1]);
     });
+
+    it("doesn't prematurely get the first element when given 0", function() {
+      expect(Lazy.generate(function (i) {return i;}).take(0).toArray()).toEqual([]);
+    })
   });
 
   describe("initial", function() {


### PR DESCRIPTION
`take(0)` on a `GeneratedSequence` would resulted in a nonempty sequence. For example:

```
> Lazy.generate(function (i) { return i; }).take(0).toArray()
[ 0 ]
```

As a consequence, ranges that should be empty weren't:

```
> Lazy.range(0).toArray()
[ 0 ]
> Lazy.range(5, 0).toArray()
[ 5 ]
```

This contradicts the behavior on other sequences:

```
> Lazy([1,2,3]).take(0).toArray()
[]
```

I assume the behavior on other sequences is correct. It makes more sense and matches underscore and lodash.

This pull request fixes the behavior and adds tests on both `range` and `generate`.

By the way, I noticed `compile:all` changed a bunch of files that weren't usually changed in you commits. `compile:lib` also changed lazy.min.js, which doesn't appear to be usually changed by your commits either. So I only added the files I changed and lazy.js. Let me know if you would prefer something different.
