### PR TITLE
Made the export for Node look for an object

### DIFF
--- a/lazy.js
+++ b/lazy.js
@@ -3886,7 +3886,7 @@
   /*** Exposing Lazy to the world ***/
 
   // For Node.js
-  if (typeof module !== "undefined") {
+  if (typeof module === "object") {
     module.exports = Lazy;
 
   // For browsers


### PR DESCRIPTION
Some libraries (such as angular-mocks) set module to a function, so this is a better safer.
