### PR TITLE
Made SplitStreamSequence work across multiple chunks for strings

### DIFF
--- a/lazy.js
+++ b/lazy.js
@@ -5213,20 +5213,32 @@
   SplitStreamSequence.prototype = new Sequence();
 
   SplitStreamSequence.prototype.each = function each(fn) {
-    var delimiter = this.delimiter,
-        done      = false,
-        i         = 0;
+    var delimiter  = this.delimiter,
+        pieceIndex = 0,
+        buffer = '',
+        bufferIndex = 0,
+        handle = new AsyncHandle(this.interval);
 
-    return this.parent.each(function(chunk) {
-      Lazy(chunk).split(delimiter).each(function(piece) {
-        if (fn(piece, i++) === false) {
-          done = true;
+    var parentHandle = this.parent.each(function(chunk) {
+      buffer += chunk;
+      var delimiterIndex;
+      while ((delimiterIndex = buffer.indexOf(delimiter)) >= 0) {
+        var piece = buffer.substr(0,delimiterIndex);
+        buffer = buffer.substr(delimiterIndex+delimiter.length);
+        if (fn(piece,pieceIndex++) === false) {
           return false;
         }
-      });
-
-      return !done;
+      }
+      return true;
     });
+    parentHandle.onComplete(function() {
+      fn(buffer,pieceIndex++);
+      handle.completeCallback();
+    });
+    parentHandle.onError(function() {
+      handle.errorCallback.apply(handle,arguments);
+    });
+    return handle;
   };
 
   StreamLikeSequence.prototype.lines = function lines() {

--- a/spec/node_spec.js
+++ b/spec/node_spec.js
@@ -73,6 +73,27 @@ describe("working with streams", function() {
     });
   });
 
+  it("can split the contents of the stream across chunks", function() {
+    var stream = new MemoryStream(),
+        pieces  = [];
+    Lazy(stream).split('to be').each(function(piece) {
+      pieces.push(piece);
+    });
+
+    stream.write('this ');
+    stream.write('needs ');
+    stream.write('to ');
+    stream.write('be ');
+    stream.write('split');
+    stream.end();
+
+    waitsFor(toBePopulated(pieces,2));
+
+    runs(function() {
+      expect(pieces).toEqual(['this needs ',' split']);
+    });
+  });
+
   it("can also do string-style matching on streams", function() {
     var stream = fs.createReadStream("./spec/data/haiku.txt"),
         words  = [];


### PR DESCRIPTION
(Hi again, sorry for the previous pull request, but apparently I still stumbled across a different problem ;) )
In my use-case of Lazy I'm reading a file that needs to be split into large pieces. The chunks that the stream spits out are smaller than the pieces I need. At the moment Lazy.js splits on each chunk separately, which results in Lazy spitting out the chunks as-is, instead of actual splitted pieces.

This also goes for line-splitting. There can be multiple lines inside one chunk. Most of those will be correct, but the lines that span across 2 chunks will be incorrect as far as I've seen.

This patch contains a solution for this by concatenating chunks and looking up the divider inside that concatenation. It also includes a test that fails with the earlier code and passes with the code in this patch.

However, some other tests fail. This is because I have only implemented a solution for string-dividers, not regexp-dividers! I need some hints as to how to solve this for regexp-dividers, since those don't have a constant length. Maybe for regexp dividers it should just fallback to the existing implementation, but that's somewhat confusing as you don't expect the output to be like this. Let me know what you think!
