### PR TITLE
Fix lazy.browser .on method

### DIFF
--- a/lazy.browser.js
+++ b/lazy.browser.js
@@ -101,7 +101,9 @@
       }
     };
 
-    this.element.addEventListener(this.eventName, listener);
+    for (var i=0; i < this.element.length; i++){
+        this.element[i].addEventListener(this.eventName, listener);
+    }
   };
 
   /**


### PR DESCRIPTION
Fixes issue #84.

The example on the site should probably also be changed. `DomEventSequence` expects a `NodeList` or an `HTMLCollection` and these will always be an array-like, but the example is acting like `sourceElement` is an individual DOM element. E.g.

```
coordinates = mouseEvents.map(function(e) {
      var elementRect = e.target.getBoundingClientRect(); // was sourceElement.getBoundingClientRect();
      return [
      Math.floor(e.clientX - elementRect.left),
      Math.floor(e.clientY - elementRect.top)
      ];
    });
```

Beyond this, I think a fully working example, that provides `displayCoordinates` as well as demonstrating how `sourceElement` should be assigned, would be a big help.
