### PR TITLE
Output streams should set delimiter

### DIFF
--- a/lazy.node.js
+++ b/lazy.node.js
@@ -138,6 +138,15 @@ if (typeof Stream.Readable !== "undefined") {
 
     this.sequence = sequence;
     this.started  = false;
+    
+    // Find delimiter on a (parent) sequence object if set
+    while (sequence) {
+      if (sequence.delimiter) {
+        this.delimiter = sequence.delimiter;
+        break;
+      }
+      sequence = sequence.parent;
+    }
   }
 
   util.inherits(LazyStream, Stream.Readable);
@@ -146,8 +155,11 @@ if (typeof Stream.Readable !== "undefined") {
     var self = this;
 
     if (!this.started) {
-      var handle = this.sequence.each(function(e, i) {
-        return self.push(e, i);
+      var handle = this.sequence.each(function(line, i) {
+        if (self.delimiter != null) {
+          line += self.delimiter;
+        }
+        return self.push(line, i);
       });
       if (handle instanceof Lazy.AsyncHandle) {
         handle.onComplete(function() {

--- a/spec/node_spec.js
+++ b/spec/node_spec.js
@@ -301,6 +301,26 @@ describe("working with streams", function() {
           expect(contents).toEqual(expected);
         });
       });
+
+      it('respects file delimiter set on the instance (e.g. by .lines())', function() {
+        var stream = Lazy.readFile('./spec/data/lines.txt')
+          .lines()
+          .take(5)
+          .toStream();
+
+        var finished = jasmine.createSpy();
+        var output = new MemoryStream(null, { readable: false });
+
+        stream.pipe(output);
+        stream.on('end', finished);
+
+        waitsFor(toBeCalled(finished));
+        runs(function() {
+          var contents = output.toString().replace(/\n$/, '');
+          var expected = Lazy.repeat('The quick brown fox jumped over the lazy dog.', 5).join('\n');
+          expect(contents).toEqual(expected);
+        });
+      });
     });
   }
 });


### PR DESCRIPTION
`LazyStream`s should use their delimiter when being outputted to a stream

Close #94
