### PR TITLE
Add a value transform function to groupBy / indexBy

### DIFF
--- a/lazy.js
+++ b/lazy.js
@@ -4068,8 +4068,8 @@
         result;
 
     result = this.parent.reduce(function(grouped,e) {
-      var key = keyFn(e);
-      var val = valFn(e);
+      var key = keyFn(e),
+          val = valFn(e);
       if (!(grouped[key] instanceof Array)) {
         grouped[key] = [val];
       } else {

--- a/lazy.js
+++ b/lazy.js
@@ -1431,6 +1431,9 @@
    * @param {Function|string} keyFn The function to call on the elements in this
    *     sequence to obtain a key by which to index them, or a string
    *     representing a property to read from all the elements in this sequence.
+   * @param {Function|string} valFn (Optional) The function to call on the elements
+   *     in this sequence to assign to the value of the indexed object, or a string
+   *     representing a parameter to read from all the elements in this sequence.
    * @returns {Sequence} The new sequence.
    *
    * @examples
@@ -1443,17 +1446,19 @@
    *     fred = people[1];
    *
    * Lazy(people).indexBy('name') // sequence: { 'Bob': bob, 'Fred': fred }
+   * Lazy(people).indexBy('name', 'age') // sequence: { 'Bob': 25, 'Fred': 34 }
    */
-  Sequence.prototype.indexBy = function(keyFn) {
-    return new IndexedSequence(this, keyFn);
+  Sequence.prototype.indexBy = function(keyFn, valFn) {
+    return new IndexedSequence(this, keyFn, valFn);
   };
 
   /**
    * @constructor
    */
-  function IndexedSequence(parent, keyFn) {
+  function IndexedSequence(parent, keyFn, valFn) {
     this.parent = parent;
     this.keyFn  = keyFn;
+    this.valFn  = valFn;
   }
 
   // IndexedSequence must have its prototype set after ObjectLikeSequence has
@@ -4086,13 +4091,16 @@
 
   IndexedSequence.prototype.each = function each(fn) {
     var keyFn   = createCallback(this.keyFn),
+        valFn   = createCallback(this.valFn),
         indexed = {};
 
     return this.parent.each(function(e) {
-      var key = keyFn(e);
+      var key = keyFn(e),
+          val = valFn(e);
+
       if (!indexed[key]) {
-        indexed[key] = e;
-        return fn(e, key);
+        indexed[key] = val;
+        return fn(val, key);
       }
     });
   };


### PR DESCRIPTION
Hey @dtao! I'm curious what you think of this tiny modification.
It allows for the following:

```javascript
var input = [
  { id: 'a', group: 'g1', value: 'Awesome stuff',    irrelevant: 'blargh' },
  { id: 'b', group: 'g1', value: 'Not to be missed', irrelevant: 'blargh' },
  { id: 'c', group: 'g2', value: 'Check it out',     irrelevant: 'blargh' },
  { id: 'd', group: 'g2', value: 'This is amazing',  irrelevant: 'blargh' }
]

lazy(input).groupBy('group', 'value').toObject()
// => { g1: [ 'Awesome stuff', 'Not to be missed' ],
//      g2: [ 'Check it out', 'This is amazing' ] }

lazy(input).indexBy('id', 'value').toObject()
// => { a: 'Awesome stuff',
//      b: 'Not to be missed',
//      c: 'Check it out',
//      d: 'This is amazing' }
```

Again, thanks for your awesome module!

Dunno if you were at ForwardJS here in SF a few weeks ago, but someone
gave a talk and mentioned lazy evaluation in javascript utility libraries.
I only caught the tail end of it, so I'm not sure what was said, but I'm
glad more people are thinking in this way now :)