### PR TITLE
added PromiseSequence that waits asynchronously for each Promise item

### DIFF
--- a/lazy.js
+++ b/lazy.js
@@ -381,6 +381,10 @@
     return result;
   };
 
+  Sequence.prototype.mapThen = function mapThen() {
+    return new PromiseSequence(this);
+  };
+
   /**
    * The Iterator object provides an API for iterating over a sequence.
    *
@@ -4985,6 +4989,56 @@
       }
     });
 
+    return handle;
+  };
+
+  function PromiseSequence(parent) {
+    if (parent instanceof AsyncSequence) {
+      throw new Error("Sequence is already asynchronous!");
+    }
+
+    this.parent = parent;
+  }
+  PromiseSequence.prototype = new AsyncSequence();
+  PromiseSequence.prototype.each = function each(fn) {
+    var iterator = this.parent.getIterator(),
+        currentPromise = null,
+        isCancelled = false,
+        i = 0;
+    var handle = new AsyncHandle(function cancel() {
+      if (currentPromise) {
+        currentPromise.cancel();
+      }
+      isCancelled = true;
+    });
+    function iterate() {
+      if (isCancelled) {
+        return;
+      }
+      try {
+        if (iterator.moveNext()) {
+          currentPromise = iterator.current();
+          currentPromise.onComplete(onComplete);
+          currentPromise.onError(onError);
+        } else {
+          handle._resolve();
+        }
+
+      } catch (e) {
+        handle._reject(e);
+      }
+    }
+    function onComplete(value) {
+      if (fn(value,i++) !== false) {
+        iterate();
+      } else {
+        handle._resolve();
+      }
+    }
+    function onError(e) {
+      handle._reject(e);
+    }
+    setImmediate(iterate);
     return handle;
   };
 

--- a/spec/async_sequence_spec.js
+++ b/spec/async_sequence_spec.js
@@ -1,4 +1,16 @@
 describe('AsyncSequence', function() {
+  function createPromise(value) {
+    var handle = new Lazy.AsyncHandle(function() {
+      clearTimeout(handle.timeoutId);
+    });
+    handle.start = function() {
+      handle.timeoutId = setTimeout(function() {
+        handle._resolve(value);
+      },0);
+    };
+    handle.start();
+    return handle;
+  }
   function testAsyncCallback(description, array, options) {
     testAllSequenceTypes(description, array, function(sequence) {
       var callback = jasmine.createSpy();
@@ -9,6 +21,20 @@ describe('AsyncSequence', function() {
 
       runs(function() {
         expect(callback.calls[0].args).toEqual(options.expectedArgs);
+      });
+    });
+
+    describe('PromiseSequence', function() {
+      testAllSequenceTypes(description, array, function(sequence) {
+        var callback = jasmine.createSpy();
+
+        options.setup(sequence.map(createPromise).mapThen(), callback);
+
+        waitsFor(toBeCalled(callback));
+
+        runs(function() {
+          expect(callback.calls[0].args).toEqual(options.expectedArgs);
+        });
       });
     });
   }


### PR DESCRIPTION
As described in the previous issue, this will allow people to create a Sequence of promises and let Lazy wait for each of them to be resolved. This allows functionality like mapping a sequence of URLs to a sequence of HTML-fetching-promises and, with `mapThen`, resolve those promises to a sequence of HTML.
