### PR TITLE
Fixed the ShuffledSequence to be truely shuffled.

### DIFF
--- a/lazy.js
+++ b/lazy.js
@@ -1641,7 +1641,7 @@
         j = 0;
 
     for (var i = shuffled.length - 1; i > 0; --i) {
-      swap(shuffled, i, floor(random() * i) + 1);
+      swap(shuffled, i, floor(random() * i));
       if (fn(shuffled[i], j++) === false) {
         return;
       }


### PR DESCRIPTION
When working with a small sequence lately, I noticed that the `.shuffle()` method, isn't working as expected. The _first_ element of the original `Sequence` would always be the _last_ of the new `ShuffledSequence`.

Test case:

``` javascript
Lazy([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).shuffle().toArray()
```

Results:

``` javascript
[1, 5, 9, 6, 4, 3, 7, 2, 8, 0]
[7, 1, 8, 9, 6, 5, 3, 2, 4, 0]
[8, 2, 9, 4, 3, 5, 7, 6, 1, 0]
[9, 8, 7, 4, 6, 5, 1, 2, 3, 0]
[2, 6, 7, 9, 4, 5, 8, 3, 1, 0]
[2, 4, 5, 6, 3, 1, 7, 9, 8, 0]
[1, 3, 9, 7, 4, 5, 6, 2, 8, 0]
[8, 7, 3, 2, 5, 9, 6, 1, 4, 0]
[4, 1, 2, 5, 7, 8, 3, 6, 9, 0]
[2, 7, 5, 6, 1, 9, 4, 3, 8, 0]
[9, 3, 7, 2, 5, 4, 6, 1, 8, 0]
[1, 9, 7, 4, 5, 2, 6, 3, 8, 0]
[5, 9, 1, 3, 4, 8, 6, 7, 2, 0]
[4, 2, 9, 7, 6, 3, 5, 8, 1, 0]
[5, 1, 8, 2, 3, 7, 6, 4, 9, 0]
[6, 9, 4, 5, 3, 1, 8, 7, 2, 0]
[5, 3, 4, 7, 1, 9, 2, 6, 8, 0]
[6, 3, 9, 2, 8, 7, 5, 4, 1, 0]
[1, 2, 5, 7, 6, 9, 3, 8, 4, 0]
[7, 8, 1, 3, 5, 9, 2, 6, 4, 0] 
```

After fix in this PR:

``` javascript
[5, 3, 6, 9, 8, 2, 4, 1, 0, 7]
[8, 4, 6, 1, 0, 7, 9, 5, 2, 3]
[5, 6, 1, 4, 3, 2, 7, 0, 8, 9]
[4, 2, 9, 1, 3, 0, 6, 5, 7, 8]
[2, 4, 3, 5, 1, 7, 9, 6, 0, 8]
[4, 2, 8, 0, 7, 6, 1, 9, 5, 3]
[2, 7, 4, 5, 9, 0, 8, 3, 6, 1]
[3, 7, 2, 4, 0, 9, 5, 1, 6, 8]
[2, 5, 0, 7, 3, 1, 6, 8, 9, 4]
[1, 3, 0, 4, 6, 2, 5, 9, 7, 8]
[4, 0, 5, 2, 3, 6, 9, 1, 8, 7]
[1, 3, 4, 8, 2, 0, 7, 9, 6, 5]
[0, 3, 6, 8, 2, 5, 1, 9, 4, 7]
[0, 1, 6, 8, 4, 3, 2, 7, 9, 5]
[1, 5, 6, 3, 0, 8, 9, 7, 4, 2]
[8, 2, 9, 3, 7, 6, 5, 1, 0, 4]
[5, 7, 2, 4, 0, 8, 9, 1, 3, 6]
[7, 9, 3, 0, 1, 2, 5, 6, 4, 8]
[5, 6, 0, 4, 3, 2, 7, 9, 8, 1]
[5, 3, 8, 2, 6, 9, 4, 0, 7, 1] 
```
