### PR TITLE
Fix #122: StringSegments do not seem to support methods like split

### DIFF
--- a/lazy.js
+++ b/lazy.js
@@ -4394,6 +4394,11 @@
     this.parent = parent;
     this.start  = Math.max(0, start);
     this.stop   = stop;
+    Object.defineProperty(this, "source", {
+      get: function() {
+        return this.toString();
+      }
+    });
   }
 
   StringSegment.prototype = new StringLikeSequence();

--- a/spec/string_like_sequence_spec.js
+++ b/spec/string_like_sequence_spec.js
@@ -21,7 +21,7 @@ describe("StringLikeSequence", function() {
       expect(result).toEqual("hel");
     });
     it("returns again a StringLikeSequence and methods like split work",function() {
-      var result = Lazy("hello").first(3).split(",");
+      var result = Lazy("hello").first(3).split(",").toArray();
       expect(result).toEqual(["hel"]);
     });
   });

--- a/spec/string_like_sequence_spec.js
+++ b/spec/string_like_sequence_spec.js
@@ -15,6 +15,17 @@ describe("StringLikeSequence", function() {
     });
   });
 
+  describe("first",function() {
+    it("slices string",function() {
+      var result = Lazy("hello").first(3).toString();
+      expect(result).toEqual("hel");
+    });
+    it("returns again a StringLikeSequence and methods like split work",function() {
+      var result = Lazy("hello").first(3).split(",");
+      expect(result).toEqual(["hel"]);
+    });
+  });
+
   describe("split", function() {
     var values = Lazy.range(10).join(", ");
 


### PR DESCRIPTION
This fixes issue #122 - implementation is not efficient, but might be acceptable.