### PR TITLE
Bug fix for shuffled sequence

### DIFF
--- a/lazy.js
+++ b/lazy.js
@@ -1670,7 +1670,7 @@
         j = 0;
 
     for (var i = shuffled.length - 1; i > 0; --i) {
-      swap(shuffled, i, floor(random() * i));
+      swap(shuffled, i, floor(random() * (i+1)));
       if (fn(shuffled[i], j++) === false) {
         return;
       }


### PR DESCRIPTION
Hi,

I've been using Lazy(arr).shuffle().first() for getting a random item from an array and I noticed that it was never returning me the last element of the original array. So I looked into the code and I found a small bug. The random number generated for swapping was not including "i", making it somehow impossible for an item to stay in its original position - that making it a biased permutation. You can see that clearly by running "Lazy(['a','b','c','d']).shuffle().reverse().toArray()" many times (reverse is needed since the shuffle returns them in reverse order).

Please let me know if you have any questions.

Thanks,
Avgoustinos