### PR TITLE
Merge types

### DIFF
--- a/lazy.js
+++ b/lazy.js
@@ -3896,19 +3896,27 @@
    * mergeObjects({ foo: { bar: 1 } }, { foo: { baz: 2 } }); // => { foo: { bar: 1, baz: 2 } }
    * mergeObjects({ foo: { bar: 1 } }, { foo: undefined }); // => { foo: { bar: 1 } }
    * mergeObjects({ foo: { bar: 1 } }, { foo: null }); // => { foo: null }
+   * mergeObjects({ array: [0, 1, 2] },              { array: [3, 4, 5] }).array.constructor.name;                // => 'Array'
+   * mergeObjects({ date: new Date() },              { date: new Date() }).date.constructor.name;                 // => 'Date'
+   * mergeObjects({ buffer: new Buffer([1, 2, 3]) }, { buffer: new Buffer([4, 5, 6]) }).buffer.constructor.name;  // => 'Buffer'
    */
   function mergeObjects(a, b) {
+    var prop, merged;
+
     if (typeof b === 'undefined') {
       return a;
     }
 
     // Unless we're dealing with two objects, there's no merging to do --
     // just replace a w/ b.
-    if (typeof a !== 'object' || a === null || typeof b !== 'object' || b === null) {
+    if (typeof a !== 'object' || a === null || typeof b !== 'object' || b === null ||
+        b.constructor === Date || Buffer.isBuffer(b)) {
+
       return b;
     }
 
-    var merged = {}, prop;
+    // if one is an array, make it an array
+    merged = Array.isArray(a) || Array.isArray(b) ? [] : {};
     for (prop in a) {
       merged[prop] = mergeObjects(a[prop], b[prop]);
     }

--- a/spec/merge_spec.js
+++ b/spec/merge_spec.js
@@ -1,0 +1,38 @@
+describe("merge", function () {
+  var object_a = {
+    string: 'foobar',
+    number: 42,
+    array: [4, 8, 15, 16, 23, 42],
+    date: new Date(),
+    buffer: new Buffer([1, 2, 3, 4, 5, 6]),
+    bool: true,
+    object: { foo:"bar" }
+  },
+  object_b = {
+    string: 'snafu',
+    number: 23,
+    array: [1, 2, 3],
+    date: new Date(0),
+    buffer: new Buffer([3, 2, 1]),
+    bool: false,
+    object: { bar:"foo" }
+  };
+
+  var merged = Lazy(object_a).merge(object_b).toObject();
+
+  it("should merge as expected", function () {
+    expect(merged.string).toEqual(object_b.string);
+    expect(merged.number).toEqual(object_b.number);
+    expect(merged.array).toEqual([1, 2, 3, 16, 23, 42]);
+    expect(merged.date).toEqual(object_b.date);
+    expect(merged.buffer).toEqual(object_b.buffer);
+    expect(merged.bool).toEqual(object_b.bool);
+    expect(merged.object).toEqual({ foo: "bar", bar: "foo" });
+  });
+
+  it("should retain types", function () {
+    for (var key in merged) {
+      expect(merged[key].constructor.name).toEqual(object_a[key].constructor.name);
+    }
+  });
+});

--- a/spec/node_spec.js
+++ b/spec/node_spec.js
@@ -26,6 +26,7 @@ require("./min_spec.js");
 require("./max_spec.js");
 require("./sum_spec.js");
 require("./watch_spec.js");
+require("./merge_spec.js");
 
 if (isHarmonySupported()) {
   require('../experimental/lazy.es6.js');


### PR DESCRIPTION
merge() doesn't consider types of properties correctly.
Arrays become Objects, while for types Date and Buffer, it seems to fail entirely:

```javascript
  var object_a = {
          string: 'foobar',
          number: 42,
          array: [4, 8, 15, 16, 23, 42],
          date: new Date(),
          buffer: new Buffer([1, 2, 3, 4, 5, 6]),
          bool: true,
          object: {
              foo: 'bar'
          }
      },
      object_b = {
          string: 'snafu',
          number: 23,
          array: [1, 2, 3],
          date: new Date(0),
          buffer: new Buffer([3, 2, 1]),
          bool: false,
          object: {
              bar: 'foo'
          }
      };

  var merged = Lazy(object_a).merge(object_b).toObject();
  console.log(JSON.stringify(Lazy(object_a).merge(object_b).toObject(), null, 4))
```

->

```json
{
    "string": "snafu",
    "number": 23,
    "array": {
        "0": 1,
        "1": 2,
        "2": 3,
        "3": 16,
        "4": 23,
        "5": 42
    },
    "date": {},
    "buffer": {
        "type": "Buffer",
        "data": [
            3,
            2,
            1
        ]
    },
    "bool": false,
    "object": {
        "foo": "bar",
        "bar": "foo"
    }
}
```

I added a test that tests for the types of properties in merged objects and made small changes to mergeOjects() to fix the behaviour.