### PR TITLE
Improve performance iterating through object fields

### DIFF
--- a/lazy.js
+++ b/lazy.js
@@ -4294,9 +4294,14 @@
 
   ObjectWrapper.prototype.each = function each(fn) {
     var source = this.source,
-        key;
+        keys = source ? Object.keys(source) : [],
+        length = keys.length,
+        key,
+        index;
 
-    for (key in source) {
+    for (index = 0; index < length; ++index) {
+      key = keys[index];
+
       if (fn(source[key], key) === false) {
         return false;
       }


### PR DESCRIPTION
I found that if you iterate via object fields using Object.keys() it works much faster than using for..in statement.
At least it works so for me in node v0.10.29 and node v0.10.36 in OS X where lazy.js beats both Underscore and Lodash in my tests with my change (I tried just 'filter' though).

If it works for you the same, I'd be glad to have it merged.

Thanks for the excellent library!
