### PR TITLE
Avoid `eval` in `cloneRegex`

### DIFF
--- a/lazy.js
+++ b/lazy.js
@@ -6104,32 +6104,32 @@
   }
 
   /**
-   * "Clones" a regular expression (but makes it always global).
+   * "Clones" a regular expression, but ensures it is always global.
+   * Will return the passed RegExp if global is already set.
    *
    * @private
    * @param {RegExp|string} pattern
    * @returns {RegExp}
    */
   function cloneRegex(pattern) {
-    var flags, global, patternStr;
-    if (typeof pattern === "string") {
-      patternStr = pattern;
-      flags = pattern.substr(pattern.lastIndexOf("/") + 1);
-      global = flags.indexOf("g") >= 0 ? "" : "g";
+    var patternStr, lsi, flags, global;
+    if (pattern instanceof RegExp) {
+      // Just return the passed in RegExp
+      if (pattern.global)
+        return pattern;
+      patternStr = pattern.toString();
     }
     else {
-      patternStr = pattern.toString();
-      // No widespread RegExp.prototype.flags, unfortuantely;
-      // We use the string approach instead!
-      flags = patternStr.substr(patternStr.lastIndexOf("/") + 1);
-      global = Boolean(pattern.global) ? "" : "g";
+      patternStr = pattern;
     }
-    var res = new RegExp(
-      patternStr.slice(1, -(flags.length + 1)),
-      flags + global
-    );
-    return res;
-  };
+    lsi = patternStr.lastIndexOf("/");
+    // No widespread RegExp.prototype.flags, unfortuantely;
+    // We use the string approach for both argument types!
+    flags = patternStr.substring(lsi + 1);
+    global = flags.indexOf("g") >= 0 ? "" : "g";
+
+    return new RegExp(patternStr.substring(1, lsi), flags + global);
+}
 
   /**
    * A collection of unique elements.

--- a/lazy.js
+++ b/lazy.js
@@ -1559,8 +1559,8 @@
    *
    * @examples
    * Lazy([1, 2, 2, 3, 3, 3]).uniq() // sequence: [1, 2, 3]
-   * Lazy([{ name: 'mike' }, 
-   * 	{ name: 'sarah' }, 
+   * Lazy([{ name: 'mike' },
+   * 	{ name: 'sarah' },
    * 	{ name: 'mike' }
    * ]).uniq('name')
    * // sequence: [{ name: 'mike' }, { name: 'sarah' }]
@@ -6111,7 +6111,24 @@
    * @returns {RegExp}
    */
   function cloneRegex(pattern) {
-    return eval("" + pattern + (!pattern.global ? "g" : ""));
+    var flags, global, patternStr;
+    if (typeof pattern === "string") {
+      patternStr = pattern;
+      flags = pattern.substr(pattern.lastIndexOf("/") + 1);
+      global = flags.indexOf("g") >= 0 ? "" : "g";
+    }
+    else {
+      patternStr = pattern.toString();
+      // No widespread RegExp.prototype.flags, unfortuantely;
+      // We use the string approach instead!
+      flags = patternStr.substr(patternStr.lastIndexOf("/") + 1);
+      global = Boolean(pattern.global) ? "" : "g";
+    }
+    var res = new RegExp(
+      patternStr.slice(1, -(flags.length + 1)),
+      flags + global
+    );
+    return res;
   };
 
   /**

--- a/lazy.node.js
+++ b/lazy.node.js
@@ -138,7 +138,7 @@ if (typeof Stream.Readable !== "undefined") {
 
     this.sequence = sequence;
     this.started  = false;
-    
+
     // Find delimiter on a (parent) sequence object if set
     while (sequence) {
       if (sequence.delimiter) {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "underscore": "1.8.3"
   },
   "scripts": {
-    "test": "npm run-script 'autodoc' && npm run-script 'jasmine' && npm run-script 'amd' && npm run-script 'promise'",
+    "test": "npm run-script autodoc && npm run-script jasmine && npm run-script amd && npm run-script promise",
     "autodoc": "autodoc -t --variable Lazy lazy.js",
     "jasmine": "jasmine-node spec/node_spec.js",
     "amd": "node spec/amd_spec.js",


### PR DESCRIPTION
The main reason to replace `eval` is for better static analysis. Build tools such as rollup spit warnings about the use of local eval.

Not only that, but `eval` seems to be slower in some situations. It's also a lot faster to just return the passed in `RegExp` if it has the global flag already set -  no need to "clone".