### PR TITLE
Make join not ignore delimiter when working with ObjectLikeSequences

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "0.12.x"
-  - "4.2.x"
-  - "5.1.x"
+  - "0.12"
+  - "4.2"
+  - "5.1"
 before_install:
   - "npm update -g npm"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "0.11"
-  - "0.10"
-  - "iojs"
+  - "0.12.x"
+  - "4.2.x"
+  - "5.1.x"
 before_install:
   - "npm update -g npm"

--- a/lazy.js
+++ b/lazy.js
@@ -2519,12 +2519,17 @@
   Sequence.prototype.join = function join(delimiter) {
     delimiter = typeof delimiter === "string" ? delimiter : ",";
 
-    return this.reduce(function(str, e, i) {
-      if (i > 0) {
-        str += delimiter;
-      }
-      return str + e;
+    var initialResult = this.reduce(function(str, e, i) {
+      return str + delimiter + e;
     }, "");
+
+    if (this.isAsync()) {
+      return initialResult.then(function(str) {
+        return str.slice(delimiter.length, str.length)
+      })
+    } else {
+      return initialResult.slice(delimiter.length, initialResult.length)
+    }
   };
 
   Sequence.prototype.toString = function toString(delimiter) {

--- a/spec/join_spec.js
+++ b/spec/join_spec.js
@@ -1,0 +1,21 @@
+describe("join", function() {
+  it("returns the empty string when passed the empty sequence", function() {
+    expect(Lazy([]).join()).toEqual("");
+  });
+
+  it("returns the only element as a string when passed a one-element sequence", function() {
+    expect(Lazy([1]).join()).toEqual("1");
+  });
+
+  it("uses comma as delimiter when no delimiter is given", function() {
+    expect(Lazy(["a", "b", "c"]).join()).toEqual("a,b,c");
+  });
+
+  it("uses given delimiter instead of comma", function() {
+    expect(Lazy(["a", "b", "c"]).join(":")).toEqual("a:b:c");
+  });
+
+  it("uses delimiter for ObjectLikeSequences, not only for ArrayLikeSequences", function() {
+    expect(Lazy({ a: "aaron", b: "brad" }).values().join(':')).toEqual("aaron:brad");
+  });
+});

--- a/spec/node_spec.js
+++ b/spec/node_spec.js
@@ -27,6 +27,7 @@ require("./max_spec.js");
 require("./sum_spec.js");
 require("./watch_spec.js");
 require("./merge_spec.js");
+require("./join_spec.js");
 
 if (isHarmonySupported()) {
   require('../experimental/lazy.es6.js');


### PR DESCRIPTION
This fixes #184.
