### PR TITLE
Attempt to fix #222

### DIFF
--- a/lazy.js
+++ b/lazy.js
@@ -3335,7 +3335,7 @@
    * Lazy([1, 2]).concat([3, 4]) // sequence: [1, 2, 3, 4]
    */
   ArrayLikeSequence.prototype.concat = function concat(var_args) {
-    if (arguments.length === 1 && isArray(arguments[0])) {
+    if (arguments.length === 1 && (isArray(arguments[0]) || arguments[0] instanceof Lazy.ArrayLikeSequence)) {
       return new IndexedConcatenatedSequence(this, (/** @type {Array} */ var_args));
     } else {
       return Sequence.prototype.concat.apply(this, arguments);
@@ -3347,7 +3347,7 @@
    */
   function IndexedConcatenatedSequence(parent, other) {
     this.parent = parent;
-    this.other  = other;
+    this.other  = other instanceof Lazy.ArrayLikeSequence ? other : Lazy(other);
   }
 
   IndexedConcatenatedSequence.prototype = Object.create(ArrayLikeSequence.prototype);
@@ -3357,12 +3357,12 @@
     if (i < parentLength) {
       return this.parent.get(i);
     } else {
-      return this.other[i - parentLength];
+      return this.other.get(i - parentLength);
     }
   };
 
   IndexedConcatenatedSequence.prototype.length = function length() {
-    return this.parent.length() + this.other.length;
+    return this.parent.length() + this.other.length();
   };
 
   /**

--- a/spec/array_like_sequence_spec.js
+++ b/spec/array_like_sequence_spec.js
@@ -1,0 +1,8 @@
+describe('ArrayLikeSequence', function() {
+  describe('unshift', function() {
+    it('returns an ArrayLikeSequence', function() {
+      var sequence = Lazy([1, 2]).unshift(3);
+      expect(sequence).toBeInstanceOf(Lazy.ArrayLikeSequence);
+    });
+  });
+});

--- a/spec/node_spec.js
+++ b/spec/node_spec.js
@@ -38,6 +38,7 @@ if (util.isHarmonySupported()) {
 }
 
 // Sequence types
+require("./array_like_sequence_spec.js");
 require("./object_like_sequence_spec.js");
 require("./string_like_sequence_spec.js");
 require("./async_sequence_spec.js");


### PR DESCRIPTION
Refactor `IndexedConcatenatedSequence` to use an `ArrayLikeSequence` for `other` property. This force `concat(ArrayLikeSequence)` to return an `ArrayLikeSequence` instead of a `Sequence` and indirectly fix #222 