### PR TITLE
docs: Fix simple typo, seqence -> sequence

### DIFF
--- a/lazy.browser.js
+++ b/lazy.browser.js
@@ -1,7 +1,7 @@
 (function(Lazy) {
 
   /**
-   * A seqence of DOM nodes.
+   * A sequence of DOM nodes.
    *
    * You can get a `DomSequence` by wrapping a `NodeList` or `HTMLCollection`
    * with `Lazy`:


### PR DESCRIPTION
There is a small typo in lazy.browser.js.

Should read `sequence` rather than `seqence`.

