### PR TITLE
Remove Google Analytics

### DIFF
--- a/site/source/javascripts/all.js
+++ b/site/source/javascripts/all.js
@@ -22,6 +22,3 @@
 //= require lib/lazy
 //= require lib/lazy.browser
 //= require lib/lazy.min
-
-// ----- Google Analytics -----
-//= require ga

--- a/site/source/javascripts/ga.js
+++ b/site/source/javascripts/ga.js
@@ -1,7 +1,0 @@
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-ga('create', 'UA-42171040-1', 'danieltao.com');
-ga('send', 'pageview');


### PR DESCRIPTION
Would you be willing to remove this Google Analytics 'functionality' from this website? There are better alternatives if you *must* keep tabs on users' activity.

Some reputable alternatives can be seen here: https://switching.software/replace/google-analytics/